### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/src/js/axpobj.js
+++ b/src/js/axpobj.js
@@ -1376,7 +1376,7 @@ export class AXPObj {
                 // 基にしてお絵カキコ
                 let elemRefId = document.getElementById('axp_post_span_referenceOekakiId');
 
-                console.log(String(this.oekaki_id), this.draftImageFile);
+                console.log("Oekaki ID: %s, Draft Image File: %s", String(this.oekaki_id), this.draftImageFile);
                 if (this.draftImageFile !== null) {
                     elemRefId.textContent = `${this._('@COMMON.DRAW_BASED')}:${getFileNameFromURL(this.draftImageFile)}`;
                 } else if (this.oekaki_id !== null) {


### PR DESCRIPTION
Potential fix for [https://github.com/satopian/axnospaint_for_Petit_Note/security/code-scanning/2](https://github.com/satopian/axnospaint_for_Petit_Note/security/code-scanning/2)

To fix the issue, we need to ensure that the untrusted value `this.oekaki_id` is not directly used in the format string of `console.log`. Instead, we should use a `%s` specifier in the format string and pass `this.oekaki_id` as a separate argument. This approach prevents any unintended interpretation of format specifiers in the untrusted input.

The fix involves modifying the `console.log` statement on line 1379 to use a safe format string. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
